### PR TITLE
Cirrus CI build on FreeBSD 11.2 added

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,11 @@
+freebsd_instance:
+  image: freebsd-11-2-release-amd64
+
+task:
+  name: FreeBSD 11.2 amd64
+  setup_script:
+    - pkg install -y cmake
+  build_script:
+    - cmake .
+    - cmake --build .
+


### PR DESCRIPTION
The software needs to be portable across all open platforms.